### PR TITLE
Fix bug in GetHostedZoneId

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 6e0fe3ca2698b12745edd03c1e60f867051406bb5b12a56ff1c59dd473d95ced
-updated: 2017-01-14T03:31:11.929433094+09:00
+hash: 99ff506c2f32129a505326b1d561998eb3d119a6a517b09bddab0f8523d19d3e
+updated: 2017-02-07T12:23:46.059691383+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 63ce630574a5ec05ecd8e8de5cea16332a5a684d
+  version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   subpackages:
   - aws
   - aws/awserr
@@ -34,4 +34,8 @@ imports:
   version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: golang.org/x/net
+  version: 236b8f043b920452504e263bc21d354427127473
+  subpackages:
+  - publicsuffix
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 6e0fe3ca2698b12745edd03c1e60f867051406bb5b12a56ff1c59dd473d95ced
-updated: 2017-01-05T22:41:33.471303814+09:00
+updated: 2017-01-14T03:31:11.929433094+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 63ce630574a5ec05ecd8e8de5cea16332a5a684d
@@ -28,6 +28,7 @@ imports:
   - private/protocol/xml/xmlutil
   - private/waiter
   - service/route53
+  - service/route53/route53iface
   - service/sts
 - name: github.com/go-ini/ini
   version: 6f66b0e091edb3c7b380f7c4f0f884274d550b67

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,7 @@
 package: .
 import:
-- package: github.com/aws/aws-sdk-go
-  version: ^1.6.10
+- package: golang.org/x/net
   subpackages:
-  - aws
-  - aws/credentials
-  - aws/session
-  - service/route53
+  - publicsuffix
+- package: github.com/aws/aws-sdk-go
+  version: v1.6.18

--- a/route53.go
+++ b/route53.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"strings"
 
+	"golang.org/x/net/publicsuffix"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -48,7 +50,11 @@ func NewRoute53(args []string) (*Route53, error) {
 	return r, nil
 }
 
-func (r *Route53) GetHostedZoneId(domain string) (string, error) {
+func (r *Route53) GetHostedZoneId(fqdn string) (string, error) {
+	suffix, _ := publicsuffix.PublicSuffix(fqdn)
+	name := strings.Split(strings.Replace(fqdn, "."+suffix, "", -1), ".")
+	domain := name[len(name)-1] + "." + suffix
+
 	params := &route53.ListHostedZonesInput{}
 	resp, err := r.Client.ListHostedZones(params)
 	if err != nil {


### PR DESCRIPTION
This PR is to fix a bug in `func GetHostedZoneId()` in `route53.go` which searches Route53 zone with the FQDN, not with the domain, making it only accepts apex domains.